### PR TITLE
bug: Fix formatting in DESCRIPTION file (erroneous newline)

### DIFF
--- a/api/src/DESCRIPTION
+++ b/api/src/DESCRIPTION
@@ -2,10 +2,8 @@ Type: Package
 Package: diagramLambda
 Title: Lambda runtime for DiAGRAM backend
 Version: 0.0.1
-Authors@R: c(
-    person("Jumping Rivers", email = "info@jumpingrivers.com", role = c("aut", "cre")),
-    person("The National Archives", email = "digitalpreservation@nationalarchives.gov.uk", role = "fnd")
-)
+Authors@R: c(person("Jumping Rivers", email = "info@jumpingrivers.com", role = c("aut", "cre")),
+             person("The National Archives", email = "digitalpreservation@nationalarchives.gov.uk", role = "fnd"))
 Description: A package for defining an R runtime for the DiAGRAM application's
     Lambda backend.
 License: file LICENSE


### PR DESCRIPTION
This PR fixes the format of the DESCRIPTION file.

As it stands, this file is not in valid DCF format. One can verify this by running `R CMD build .` from the `src/` directory.

This PR fixes the formatting. This fix can be verified by seeing that `R CMD build .` will now run successfully.