### PR TITLE
ci: Amend workflow to deploy from branch to matching AWS environment

### DIFF
--- a/.github/workflows/update-backend.yml
+++ b/.github/workflows/update-backend.yml
@@ -4,36 +4,33 @@ on:
   push:
     paths:
       - api/**
+    branches:
+      - live
+      - stage
+      - dev
 
 jobs:
 
   push_to_env_matching_branch:
+    environment: ${{ github.ref_name }}
     runs-on: ubuntu-latest
     if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
-
-    strategy:
-      matrix:
-        config:
-          - {branch: master, aws_region: eu-west-2 }
 
     steps:
 
       - uses: actions/checkout@v3
-        if: ${{ contains(github.ref, matrix.config.branch) }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ matrix.config.aws_region }}
-        if: ${{ contains(github.ref, matrix.config.branch) }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Login to ECR
         uses: docker/login-action@v2
         with:
-          registry: ${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ matrix.config.aws_region }}.amazonaws.com
-        if: ${{ contains(github.ref, matrix.config.branch) }}
+          registry: ${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
 
       - name: Build docker image and push to ECR
         id: docker_build
@@ -41,12 +38,9 @@ jobs:
         with:
           context: api/
           push: true
-          tags: ${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ matrix.config.aws_region }}.amazonaws.com/${{ secrets.ECR_REPO_NAME }}:latest
-        if: ${{ contains(github.ref, matrix.config.branch) }}
+          tags: ${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPO_NAME }}:latest
 
       - name: Update Lambda to use the latest image push
         run: |
-          aws lambda update-function-code --function-name ${{ secrets.LAMBDA_NAME }} --image-uri ${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ matrix.config.aws_region }}.amazonaws.com/${{ secrets.ECR_REPO_NAME }}@${{ steps.docker_build.outputs.digest }}
+          aws lambda update-function-code --function-name ${{ secrets.LAMBDA_NAME }} --image-uri ${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPO_NAME }}@${{ steps.docker_build.outputs.digest }}
           aws lambda wait function-updated --function-name ${{ secrets.LAMBDA_NAME }}
-        if: ${{ contains(github.ref, matrix.config.branch) }}
-


### PR DESCRIPTION
This PR changes the GitHub workflow such that the runner runs on the environment defined by the branch.

This means that pushes to the `dev` branch run on the `dev` environment, and push changes to the AWS dev account. Pushes to `live` push to the `live` AWS account and so on.

The environments have been configured such that secrets for each env are only accessible from specific branches. so eg. dev can't accidentally read live's secrets