### PR TITLE
fix: Update placeholder values in reference models

### DIFF
--- a/app/frontend/scripts/api.js
+++ b/app/frontend/scripts/api.js
@@ -1,7 +1,15 @@
 (function() {
 	'use strict';
 
-	var BASEURL = 'https://nata-dia2.jmpr.io/api/staging/';
+	var siteUrls = [
+		'https://diagram.nationalarchives.gov.uk',
+		'https://dev-diagram.nationalarchives.gov.uk',
+		'https://staging-diagram.nationalarchives.gov.uk'
+	];
+
+	var defaultUrl = siteUrls[0];
+
+	var BASEURL = (siteUrls[siteUrls.indexOf(window.location.origin)] || defaultUrl) + '/api/';
 	var SCOREURL = BASEURL + 'model/score';
 	var VALIDATEURL = BASEURL + 'validation/validate_json';
 	var PDFURL = BASEURL + 'report/pdf';

--- a/app/frontend/scripts/example-models.js
+++ b/app/frontend/scripts/example-models.js
@@ -6,43 +6,49 @@
 		{
 			model_name: 'Example - Commercial Backup',
 			scenario: 'Base Model',
-			notes: 'This archive that has no knowledge of digital preservation but outsources their data storage of their born-digital records. They have an inventory of content but nothing more and have not thought about preserving or rendering content, only storing the bit-stream.',
+			notes: 'The archive has no knowledge of digital preservation but outsources their data storage of their born-digital records. They have an inventory of content but nothing more and have not thought about preserving or rendering content, only storing the bit-stream.',
 			is_advanced: false,
-			intellectual_control: 92,
-			renderability: 80,
+			intellectual_control: 6,
+			renderability: 38,
 			response: {
-				Op_Environment: {
-					1: 0,
-					2: 'Not Applicable - we have copies offsite'
-				},
-				Info_Management: {
-					1: 'Not achieved',
-					2: 'Not achieved',
-					3: [
-						'Minimal awareness',
-						'Minimal awareness'
-					]
-				},
-				Rep_and_Refresh: {
-					1: 100,
-					2: 100
-				},
-				System_Security: {
-					1: 'ISO 27001',
-					2: 'None, or only minor issues outstanding',
-					3: 'Level 4',
-					4: 'Yes'
-				},
 				Digital_Object: [
+					100,
+					0,
+					0
+				],
+				Storage_Medium: [
 					0,
 					0,
 					100
 				],
+				Rep_and_Refresh: {
+					1: 100,
+					2: 100
+				},
+				Op_Environment: {
+					1: 100,
+					2: 'Not Applicable - we have copies offsite'
+				},
+				Physical_Disaster: 'Very Low',
 				Checksum: [
 					0,
-					9,
-					91
+					0,
+					100
 				],
+				System_Security: {
+					1: 'ISO 27001',
+					2: 'No test',
+					3: 'Level 2',
+					4: 'No'
+				},
+				Info_Management: {
+					1: 'Level 1',
+					2: 'Not achieved',
+					3: [
+						'Minimal awareness',
+						'Awareness'
+					]
+				},
 				Technical_Skills: [
 					'None',
 					'None',
@@ -54,13 +60,7 @@
 					'None',
 					'None',
 					'None'
-				],
-				Storage_Medium: [
-					0,
-					0,
-					100
-				],
-				Physical_Disaster: 'Very Low'
+				]
 			},
 			advanced: null
 		},
@@ -111,17 +111,17 @@
 					]
 				},
 				Technical_Skills: [
-				 'Advanced',
-				 'Advanced',
-				 'Advanced',
-				 'Advanced',
-				 'Advanced',
-				 'Advanced',
-				 'Advanced',
-				 'Advanced',
-				 'Advanced',
-				 'Advanced'
-				]
+					'Advanced',
+					'Advanced',
+					'Advanced',
+					'Advanced',
+					'Advanced',
+					'Advanced',
+					'Advanced',
+					'Advanced',
+					'Advanced',
+					'Advanced'
+			    ]
 			},
 			advanced: null
 		},

--- a/app/frontend/scripts/example-models.js
+++ b/app/frontend/scripts/example-models.js
@@ -67,61 +67,61 @@
 		{
 			model_name: 'Example - Established National Archive',
 			scenario: 'Base Model',
-			notes: 'There is a dedicated digital archive infrastructure to record and manage information about material. Multiple copies of the bit-stream are maintained on and off site on stable media and new copies are automatically made whenever an error is detected. Staff are experts in preservation practices and the archive has reasonable control over metadata requirements from depositors.',
+			notes: 'There is a dedicated digital archive infrastructure to record and manage information about material. Multiple copies of the bit-stream are maintained on and off site on stable media and new copies are automatically made whenever an error is detected. Staff are experts in preservation practices and very active in digital preservation communities. The archive has reasonable control over metadata requirements from depositors.',
 			is_advanced: false,
-			intellectual_control: 92,
-			renderability: 80,
+			intellectual_control: 60,
+			renderability: 61,
 			response: {
-				Op_Environment: {
-					1: 0,
-					2: 'Not Applicable - we have copies offsite'
-				},
-				Info_Management: {
-					1: 'Not achieved',
-					2: 'Not achieved',
-					3: [
-						'Minimal awareness',
-						'Minimal awareness'
-					]
-				},
+				Digital_Object: [
+					20,
+					0,
+					80
+				],
+				Storage_Medium: [
+					0,
+					100,
+					0
+				],
 				Rep_and_Refresh: {
 					1: 100,
 					2: 100
 				},
+				Op_Environment: {
+					1: 100,
+					2: 'Not Applicable - we have copies offsite'
+				},
+				Physical_Disaster: 'Medium',
+				Checksum: [
+					99,
+					1,
+					0
+				],
 				System_Security: {
 					1: 'ISO 27001',
 					2: 'None, or only minor issues outstanding',
-					3: 'Level 4',
+					3: 'Level 3',
 					4: 'Yes'
 				},
-				Digital_Object: [
-					0,
-					0,
-					100
-				],
-				Checksum: [
-					0,
-					9,
-					91
-				],
+				Info_Management: {
+					1: 'Level 3',
+					2: 'Level 4',
+					3: [
+						'Optimized',
+						'Optimized'
+					]
+				},
 				Technical_Skills: [
-					'None',
-					'None',
-					'None',
-					'None',
-					'None',
-					'None',
-					'None',
-					'None',
-					'None',
-					'None'
-				],
-				Storage_Medium: [
-					0,
-					0,
-					100
-				],
-				Physical_Disaster: 'Very Low'
+				 'Advanced',
+				 'Advanced',
+				 'Advanced',
+				 'Advanced',
+				 'Advanced',
+				 'Advanced',
+				 'Advanced',
+				 'Advanced',
+				 'Advanced',
+				 'Advanced'
+				]
 			},
 			advanced: null
 		},


### PR DESCRIPTION
Closes #56 and #54

The changes in this MR can be seen @ https://dev-diagram.nationalarchives.gov.uk/visualise.html.

By default only the "Example -  Commerical Backup" model is selected. To generate the screenshot below a user must also select the checkbox for "Example - Established National Archive"

![image](https://user-images.githubusercontent.com/32269169/193849630-ee3ab128-cbd9-4c34-9363-55badf56091d.png)