### PR TITLE
Add workflow to update site on changes to app/

### DIFF
--- a/.github/workflows/update-frontend.yml
+++ b/.github/workflows/update-frontend.yml
@@ -1,0 +1,43 @@
+name: Update frontend application
+
+on:
+  push:
+    paths:
+      - app/**
+      - .github/workflow/update-frontend.yml
+    branches:
+      - live
+      - stage
+      - dev
+
+jobs:
+
+  update_site_env_matching_branch:
+    environment: ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
+
+    steps:
+
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Install node dependencies
+        working-directory: ./app
+        run: npm ci
+
+      - name: Build static site 
+        working-directory: ./app
+        run: npm run build
+
+      - name: Update static site hosted in S3
+        run: aws s3 sync ./app/dist s3://${{ secrets.BUCKET_NAME }}/ --delete

--- a/app/README.md
+++ b/app/README.md
@@ -20,4 +20,4 @@ To build for production run
 npm run build
 ```
 
-This will place the built files inside a "dist" directory.
+This will place the built files inside a `dist/` directory.

--- a/app/package.json
+++ b/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "diagram-plumber",
+  "name": "DiAGRAM",
   "version": "1.0.0",
   "description": "",
   "devDependencies": {
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@gitlab.com:jumpingrivers/projects/the-national-archive-tna/dia2/diagram-plumber.git"
+    "url": "git@github.com:nationalarchives/DiAGRAM.git"
   },
   "author": ""
 }


### PR DESCRIPTION
Closes #46.

This change adds a GitHub workflow that updates the application's frontend in the environment associated with the current branch.

To test that this workflow behaves as expected, I made a change to `app/frontend/styles/styles.css`, which should change the "DiAGRAM" text in the top left of the application to be displayed in red, rather than white.

As this change has been made on the `dev` branch, the workflow introduced in this PR updated the static site hosted at: https://dev-diagram.nationalarchives.gov.uk/.

In visiting this URL, note that the "DiAGRAM" text in the top left _is_ now displayed in red (see screenshot), indicating the success of this test.

If we are satisfied with the behaviour of this workflow, I will revert the test change to the colour of the DiAGRAM text and then merge this PR.

![image](https://user-images.githubusercontent.com/32269169/194027974-c9d1669b-a1f8-4e31-bd97-608192f9c172.png)
