### PR TITLE
Add focus styling to main when user chooses "Skip to main content"

### DIFF
--- a/app/frontend/styles/styles.css
+++ b/app/frontend/styles/styles.css
@@ -324,6 +324,11 @@ button:disabled, input[type=button]:disabled {
     left: auto;
 }
 
+main:focus-visible {
+    box-shadow: inset 0 0 20px #222200;
+    border: 1px solid black;
+}
+
 
 @media screen and (max-width: 800px) {
     .content {


### PR DESCRIPTION
This just makes it clear where focus is after user has hit the skip link.

This wasn't explicitly mentioned in the accessibility report but it bothered me that focus does seem to kind of get lost after activating the skip link.