### PR TITLE
bring cypress versions in sync

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "cypress": "^14.3.3"
+        "cypress": "^14.4.0"
       }
     },
     "node_modules/@cypress/request": {


### PR DESCRIPTION
Possibly a very quick change to avoid a "versions not in sync" error when running e2e tests