### PR TITLE
DR2-2323 Stop using proxy for route

### DIFF
--- a/api/src/R/deserialise.R
+++ b/api/src/R/deserialise.R
@@ -19,6 +19,6 @@ gateway_payload_to_rook = function(event_content) {
   req$HTTP_CONTENT_TYPE = "application/json"
   req$postBody = body
   # Extract route, removing a trailing slash is there is one
-  req$route = sub("/$", "", parsed_event$pathParameters$proxy)
+  req$route = sub("/$", "", sub("^/api/", "", parsed_event$path))
   req
 }


### PR DESCRIPTION
This line https://github.com/nationalarchives/DiAGRAM/blob/dev/api/src/R/deserialise.R#L22
uses the .pathParameters.proxy value to get the route.

This isn’t available if you don’t use the {proxy} route so it needs updating
to use the path and strip /api/from the front
