### PR TITLE
Override transitive dependency to use a patched version

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -731,7 +731,6 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -1669,9 +1668,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,5 +4,11 @@
   },
   "scripts": {
     "test": "cypress run --browser chrome --headless --e2e --spec 'cypress/e2e/**/*.cy.js'"
+  },
+  "overrides": {
+    "qs": "^6.14.1"
+  },
+  "_securityNotes": {
+    "qs": "qs version is overridden above as the current version (6.14.0) brought in by cypress has a vulnerability CVE-2025-15284, remove the overrides section when cypress is updated and brings in the patched dependency"
   }
 }


### PR DESCRIPTION
Branch name is slightly misleading.

For `qs`, the version which is brought in by cypress as a dependency has a vulnerability. The latest version of cypress brings in a vulnerable `qs`, this PR overrides the vulnerable dependency to bring in a patched version.