### PR TITLE
DR2-2686 Use updated lambda rie image.

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.8 AS lambda-image
+FROM public.ecr.aws/lambda/provided AS lambda-image
 
 FROM ubuntu:noble
 


### PR DESCRIPTION
The affected version of go is bundled in the /usr/local/bin/aws-lambda-rie
which comes from the lambda/python:3.8 image.

The provided image doesn't have the vulnerability. I've scanned this
locally and it's not showing any criticals.

I don't know if this will work and there's no easy way to test this
locally so I'm going to merge this and see if the tests catch any
problems.
