### PR TITLE
Remove GitHub actions calls.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,19 +42,6 @@ jobs:
       - name: Wait for domain to be available
         run: while ! curl -s -o /dev/null -w "%{http_code}" https://dev-diagram.nationalarchives.gov.uk | grep -q "^200$"; do sleep 60; done
       - run: npm --prefix tests cit
-
-      - name: Send success message
-        uses: nationalarchives/dr2-github-actions/.github/actions/slack-send@main
-        with:
-          message: "*DiAGRAM* The e2e tests for environment: 'dev' finished successfully"
-          slack-url: ${{ secrets.SLACK_WEBHOOK }}
-
-      - name: Send failure message
-        uses: nationalarchives/dr2-github-actions/.github/actions/slack-send@main
-        if: failure()
-        with:
-          message: ":warning: e2e tests failed for DiAGRAM for environment: 'dev'"
-          slack-url: ${{ secrets.SLACK_WEBHOOK }}
   destroy-environment:
     runs-on: ubuntu-latest
     needs: run-cypress-e2e-tests

--- a/.github/workflows/update-backend.yml
+++ b/.github/workflows/update-backend.yml
@@ -40,7 +40,7 @@ jobs:
           gpg --verify /tmp/wizcli-sha256.sig /tmp/wizcli-sha256
           echo "$(cat /tmp/wizcli-sha256) wizcli" | sha256sum --check
       - id: next-tag
-        uses: nationalarchives/dr2-github-actions/.github/actions/get-next-version@main
+        run: echo next-version=$(curl -s $GITHUB_API_URL/repos/nationalarchives/DiAGRAM/tags | jq -r '.[0].name' | awk -F. -v OFS=. '{ $3++; print }') >> "$GITHUB_OUTPUT"
         with:
           repo-name: DiAGRAM
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f #v3.12.0

--- a/.github/workflows/update-backend.yml
+++ b/.github/workflows/update-backend.yml
@@ -41,8 +41,6 @@ jobs:
           echo "$(cat /tmp/wizcli-sha256) wizcli" | sha256sum --check
       - id: next-tag
         run: echo next-version=$(curl -s $GITHUB_API_URL/repos/nationalarchives/DiAGRAM/tags | jq -r '.[0].name' | awk -F. -v OFS=. '{ $3++; print }') >> "$GITHUB_OUTPUT"
-        with:
-          repo-name: DiAGRAM
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f #v3.12.0
       - name: Build docker image and push to ECR
         id: docker_build


### PR DESCRIPTION
The slack messages are unnecessary because we get them in the Github bot
channel.

I've replaced the get-next-version one as well.
